### PR TITLE
Fix bug where arrays with dict displayed wrong

### DIFF
--- a/pyaml/__init__.py
+++ b/pyaml/__init__.py
@@ -81,7 +81,7 @@ def dump(data, dst=unicode, safe=False, force_embed=False, vspacing=None):
 				self.state = self.states.pop()
 			else:
 				self.write_indent()
-				self.write_indicator('  -', True, indention=True)
+				self.write_indicator('-', True, indention=True)
 				self.states.append(self.expect_block_sequence_item)
 				self.expect_node(sequence=True)
 		yaml.emitter.Emitter.expect_block_sequence_item = expect_block_sequence_item


### PR DESCRIPTION
When executing the following code:

```
import pyaml
import collections
m = {'items': [{"template": "test", "otherval": "test2"}, {"group": "group1", "test2": "test"}]}
v = {"t": [1 , 3, 4 ], "xxx" : m, 'zzz': {"testing": "testing", "bal": "test"}}
k = collections.OrderedDict(v)
print pyaml.dump(k)
```

This outputs an invalid yaml that should be valid. The pull request fixes this.
