### PR TITLE
fixed maximum recursion error

### DIFF
--- a/pyaml/tests/test_monkey_patch.py
+++ b/pyaml/tests/test_monkey_patch.py
@@ -1,0 +1,41 @@
+import pyaml
+from unittest import TestCase
+import yaml
+
+
+class TestPyaml(TestCase):
+    def test_monkey_patch(self):
+    	d = {'a': {'b': 'c'}}
+
+	# test default
+	pyaml.dump(d)
+	self.assertFalse(pyaml.patched_values['safe'])
+	self.assertFalse(pyaml.patched_values['force_embed'])
+	self.assertTrue(pyaml.patched_values['patched'])
+
+	self.assertTrue(hasattr(yaml.serializer.Serializer, 'orig_anchor_node'))
+	self.assertTrue(hasattr(yaml.serializer.Serializer, 'orig_serialize_node'))
+	self.assertTrue(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence'))
+	self.assertTrue(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence_item'))
+
+	# test resetting
+	pyaml.dump(d, safe=True)
+	self.assertTrue(pyaml.patched_values['safe'])
+	self.assertFalse(pyaml.patched_values['force_embed'])
+	self.assertTrue(pyaml.patched_values['patched'])
+
+	self.assertFalse(hasattr(yaml.serializer.Serializer, 'orig_anchor_node'))
+	self.assertFalse(hasattr(yaml.serializer.Serializer, 'orig_serialize_node'))
+	self.assertFalse(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence'))
+	self.assertFalse(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence_item'))
+
+	# test patching again
+	pyaml.dump(d, force_embed=True)
+	self.assertFalse(pyaml.patched_values['safe'])
+	self.assertTrue(pyaml.patched_values['force_embed'])
+	self.assertTrue(pyaml.patched_values['patched'])
+
+	self.assertTrue(hasattr(yaml.serializer.Serializer, 'orig_anchor_node'))
+	self.assertTrue(hasattr(yaml.serializer.Serializer, 'orig_serialize_node'))
+	self.assertTrue(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence'))
+	self.assertTrue(hasattr(yaml.emitter.Emitter, 'orig_expect_block_sequence_item'))

--- a/pyaml/tests/test_pyaml.py
+++ b/pyaml/tests/test_pyaml.py
@@ -1,0 +1,8 @@
+import pyaml
+from unittest import TestCase
+
+
+class TestPyaml(TestCase):
+    def test_dump_max_recusion(self):
+        for i in range(0, 200):
+            pyaml.dump({'a': 'b'})


### PR DESCRIPTION
If pyaml.dump was called multiple times it ran into an maximum
recursion error. This was because on each call, the original
Serializer.serialize_node was wrapped with a new one over and over
again.

Also added some tests.

To reproduce the problem, take tests/test_pyaml.py only, and use
py.test to run the code. The test will result in an
RuntimeError: maximum recursion depth exceeded
