### PR TITLE
Fix ascii codec can't decode byte 0xd0 in position 2279

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+from codecs import open
 from setuptools import setup, find_packages
 import os
 
 pkg_root = os.path.dirname(__file__)
 
 # Error-handling here is to allow package to be built w/o README included
-try: readme = open(os.path.join(pkg_root, 'README.txt')).read()
+try: readme = open(os.path.join(pkg_root, 'README.txt'), encoding='utf-8').read()
 except IOError: readme = ''
 
 setup(


### PR DESCRIPTION
Downloading/unpacking pyaml (from pytoolbox->-r /home/famille/souvenirs_test/server/requirements.txt (line 18))
  Downloading pyaml-13.12.0.tar.gz
  Running setup.py (path:/tmp/pip_build_famille/pyaml/setup.py) egg_info for package pyaml
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_famille/pyaml/setup.py", line 9, in <module>
        try: readme = open(os.path.join(pkg_root, 'README.txt')).read()
      File "/usr/lib/python3.3/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 2279: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_famille/pyaml/setup.py", line 9, in <module>

```
try: readme = open(os.path.join(pkg_root, 'README.txt')).read()
```

  File "/usr/lib/python3.3/encodings/ascii.py", line 26, in decode

```
return codecs.ascii_decode(input, self.errors)[0]
```

UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 2279: ordinal not in range(128)
