### PR TITLE
Preserve OrderedDict order

### DIFF
--- a/pyaml/__init__.py
+++ b/pyaml/__init__.py
@@ -66,7 +66,7 @@ class PrettyYAMLDumper(yaml.dumper.SafeDumper):
 					self.anchor_node(value, hint=hint+[key])
 
 PrettyYAMLDumper.add_representer(defaultdict, PrettyYAMLDumper.represent_dict)
-PrettyYAMLDumper.add_representer(OrderedDict, PrettyYAMLDumper.represent_dict)
+PrettyYAMLDumper.add_representer(OrderedDict, PrettyYAMLDumper.represent_odict)
 PrettyYAMLDumper.add_representer(set, PrettyYAMLDumper.represent_list)
 PrettyYAMLDumper.add_representer(None, PrettyYAMLDumper.represent_undefined)
 

--- a/pyaml/tests/dump.py
+++ b/pyaml/tests/dump.py
@@ -360,6 +360,11 @@ class DumpTests(unittest.TestCase):
 		val_str = pyaml.dump(val)
 		self.assertEqual(val_str, u'y: 1\nx: 2\nz: 3\n') # namedtuple order was preserved
 
+	def test_ordereddict(self):
+		d = OrderedDict((i, '') for i in reversed(range(10)))
+		lines = pyaml.dump(d).strip().split('\n')
+		assert sorted(lines) == list(reversed(lines))
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
`pyaml.dump` should print OrderedDict in order.