### PR TITLE
Pin PyYAML 5.1 version in order to support deterministic builds of upstream projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 		'Topic :: Software Development',
 		'Topic :: Software Development :: Libraries :: Python Modules' ],
 
-	install_requires = ['PyYAML'],
+	install_requires = ['PyYAML==5.1'],
 	packages = find_packages(),
 	package_data = {'': ['README.txt']},
 	exclude_package_data = {'': ['README.*']} )


### PR DESCRIPTION
Hi @mk-fg, could you please take a look? I think this change is pretty useful, since a few days ago an unpinned `PyYAML` from `pyaml` crashed a pretty important production system. :-) Thanks in advance! Please let me know if I should adjust/change this PR somehow.

