### PR TITLE
Update github status URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,7 @@ Some Tricks
 * Pretty-print any yaml or json (yaml subset) file from the shell::
 
     % python -m pyaml /path/to/some/file.yaml
-    % curl -s https://status.github.com/api.json | python -m pyaml
+    % curl -s https://www.githubstatus.com/api/v2/summary.json | python -m pyaml
 
 * Process and replace json/yaml file in-place::
 


### PR DESCRIPTION
It seems status.github.com has been moved to it's own domain, and accessing any sub-path redirects to the root of githubstatus.com. The API endpoints can be found by going to https://www.githubstatus.com/api

The summary url provides more verbose output:
```sh
% curl -s https://www.githubstatus.com/api/v2/summary.json | python3 -m pyaml
```
<details>

```yaml
components:
  - created_at: 2017-01-31T20:05:05.370Z
    description: 'Performance of git clones, pulls, pushes, and associated operations'
    group: false
    group_id:
    id: 8l4ygp009s5s
    name: 'Git Operations'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 1
    showcase: true
    status: operational
    updated_at: 2019-12-13T18:46:03.911Z
  - created_at: 2017-01-31T20:01:46.621Z
    description: 'Requests for GitHub APIs'
    group: false
    group_id:
    id: brv1bkgrwx7q
    name: 'API Requests'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 2
    showcase: true
    status: operational
    updated_at: 2019-12-13T18:46:02.799Z
  - created_at: 2019-11-13T18:00:24.256Z
    description: 'Real time HTTP callbacks of user-generated and system events'
    group: false
    group_id:
    id: 4230lsnqdsld
    name: Webhooks
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 3
    showcase: true
    status: operational
    updated_at: 2019-12-19T23:13:07.086Z
  - created_at: 2018-12-05T19:39:40.838Z
    description:
    group: false
    group_id:
    id: 0l2p9nhqnxpd
    name: 'Visit www.githubstatus.com for more information'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 4
    showcase: false
    status: operational
    updated_at: 2019-11-13T18:02:47.782Z
  - created_at: 2017-01-31T20:01:46.638Z
    description: 'Web requests for github.com UI and services'
    group: false
    group_id:
    id: kr09ddfgbfsf
    name: 'Issues, PRs, Projects'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 5
    showcase: true
    status: operational
    updated_at: 2019-12-13T18:46:06.900Z
  - created_at: 2019-11-13T18:02:19.432Z
    description: 'Workflows, Compute and Orchestration for GitHub Actions'
    group: false
    group_id:
    id: br0l2tvcx85d
    name: 'GitHub Actions'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 6
    showcase: true
    status: operational
    updated_at: 2019-12-13T18:46:01.547Z
  - created_at: 2019-11-13T18:02:40.064Z
    description: 'API requests and webhook delivery for GitHub Packages'
    group: false
    group_id:
    id: st3j38cctv9l
    name: 'GitHub Packages'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 7
    showcase: true
    status: operational
    updated_at: 2019-12-10T11:40:31.724Z
  - created_at: 2017-01-31T20:04:33.923Z
    description: 'Frontend application and API servers for Pages builds'
    group: false
    group_id:
    id: vg70hn9s2tyj
    name: 'GitHub Pages'
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 8
    showcase: true
    status: operational
    updated_at: 2019-12-13T18:46:06.226Z
  - created_at: 2019-11-13T18:03:05.012Z
    description: Other
    group: false
    group_id:
    id: 5l5rlzqm4yzy
    name: Other
    only_show_if_degraded: false
    page_id: kctbh9vrtdwd
    position: 9
    showcase: false
    status: operational
    updated_at: 2019-12-19T23:13:02.972Z
incidents: []
page:
  id: kctbh9vrtdwd
  name: GitHub
  time_zone: Etc/UTC
  updated_at: 2020-01-02T08:09:33.450Z
  url: https://www.githubstatus.com
scheduled_maintenances: []
status:
  description: 'All Systems Operational'
  indicator: none
```

</details>
While the status endpoint provides a briefer "rollup" summary:

```sh
% curl -s https://www.githubstatus.com/api/v2/status.json | python3 -m pyaml
```
<details>

```yaml
page:
  id: kctbh9vrtdwd
  name: GitHub
  time_zone: Etc/UTC
  updated_at: 2020-01-02T08:09:33.450Z
  url: https://www.githubstatus.com
status:
  description: 'All Systems Operational'
  indicator: none
```

</details>

Neither of which are terribly complex, but do demonstrate the functionality the same.