### PR TITLE
Fix tests for Python 3.10: abstract base classes have moved

### DIFF
--- a/pyaml/tests/dump.py
+++ b/pyaml/tests/dump.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals, print_function
 
 import itertools as it, operator as op, functools as ft
-from collections import Mapping, OrderedDict, namedtuple
+from collections import OrderedDict, namedtuple
+from collections.abc import Mapping
 import os, sys, io, yaml, unittest
 
 if sys.version_info.major > 2: unicode = str


### PR DESCRIPTION
Hi,
Without this, tests fail with
```
    from collections import Mapping, OrderedDict, namedtuple
ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```

As mentioned in the documentation:
> Deprecated since version 3.3, will be removed in version 3.10: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.9.