### PR TITLE
Fix import error in pyaml script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ readme = {file="README.rst"}
 anchors = ["unidecode"]
 
 [project.scripts]
-pyaml = "pyaml.__main__:main"
+pyaml = "pyaml.cli:main"


### PR DESCRIPTION
There is no main in _main_.py, so the import fails. This patch fixes it by redirecting the import to cli.py